### PR TITLE
Correct handling of single-Address case

### DIFF
--- a/networkd-dispatcher
+++ b/networkd-dispatcher
@@ -129,14 +129,13 @@ def property_changed(typ, data, _, path):
 
         # filter out uninteresting addresses
         addrs = []
-        if type(data['Address']) != list:
-            addrs = [data['Address']]
-        else:
-            for addr in data['Address']:
-                if addr.startswith('127.') or \
-                   addr.startswith('fe80:'):
-                    continue
-                addrs.append(addr)
+        if isinstance(data['Address'], (str, bytes)):
+            data['Address'] = [data['Address']]
+        for addr in data['Address']:
+            if addr.startswith('127.') or \
+               addr.startswith('fe80:'):
+                continue
+            addrs.append(addr)
     script_list = get_scripts_list(state)
     if script_list is None:
         return


### PR DESCRIPTION
Code under `if 'Address' in data:`, would refer to `data['Address']` rather than to `addrs`; and thus would be iterating over characters in a single string rather than addresses in a list in this case, since only `addrs` is unconditionally made into a list.

Moreover, this change means that elimination of local addresses now happens regardless of whether only a single address, or more than one, is assigned to a given interface.
