### PR TITLE
Fix handling of routable interfaces with no Address

### DIFF
--- a/networkd-dispatcher
+++ b/networkd-dispatcher
@@ -132,9 +132,9 @@ def property_changed(typ, data, _, path):
 
         # filter out uninteresting addresses
         addrs = []
-        if isinstance(data['Address'], (str, bytes)):
+        if isinstance(data.get('Address'), (str, bytes)):
             data['Address'] = [data['Address']]
-        for addr in data['Address']:
+        for addr in data.get('Address', ()):
             if addr.startswith('127.') or \
                addr.startswith('fe80:'):
                 continue


### PR DESCRIPTION
Resolves a regression in 8ee0b738e4c0d0afeb675c9356347658b3846647 where codepaths assuming an Address to be present are reachable in cases where no Address necessarily exists.