### PR TITLE
Honor `$networkd_dispatcher_args` in systemd service file

### DIFF
--- a/networkd-dispatcher.service
+++ b/networkd-dispatcher.service
@@ -3,7 +3,10 @@ Description=Dispatcher daemon for systemd-networkd
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/networkd-dispatcher
+ExecStart=/usr/bin/networkd-dispatcher $networkd_dispatcher_args
+
+# Load /etc/conf.d/networkd-dispatcher.conf
+EnvironmentFile=-/etc/conf.d/%p.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This allows `/etc/conf.d/networkd-dispatcher.conf` to be created with command-line arguments to be passed to the networkd-dispatcher service on startup without needing to override the `ExecStart` line.