### PR TITLE
Limit log prefix to only contain level/severity

### DIFF
--- a/networkd-dispatcher
+++ b/networkd-dispatcher
@@ -40,6 +40,8 @@ NETWORKCTL = resolve_path(NETWORKCTL_PATHS)
 IWCONFIG = resolve_path(IWCONFIG_PATHS)
 DEFAULT_SCRIPT_DIR = '/etc/networkd-dispatcher'
 
+LOG_FORMAT = '%(levelname)s:%(message)s'
+
 STATE_IGN = {'carrier', 'degraded', None}
 SINGLETONS = {'Type', 'ESSID', 'OperationalState'}
 
@@ -308,7 +310,7 @@ def main():
         log_level = logging.INFO
     else:
         log_level = logging.DEBUG
-    logging.basicConfig(level=log_level)
+    logging.basicConfig(level=log_level, format=LOG_FORMAT)
 
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 


### PR DESCRIPTION
Otherwise our logs contained the module name; since this software only consists of a single module, this was redundant with journald's storage of the process responsible for a given log element.

(It *is* possible that libraries we use will attempt to log through the Python logging framework as well; however, that doesn't appear to be happening to any substantial degree in practice).