### PR TITLE
Use utf-8 for strings, update test runner to py3

### DIFF
--- a/networkd-dispatcher
+++ b/networkd-dispatcher
@@ -76,7 +76,7 @@ def get_networkctl_list():
                                    '--no-legend'])
     result = []
     for line in out.split(b'\n')[:-1]:
-        fields = line.decode('ascii').split()
+        fields = line.decode('utf-8', errors='replace').split()
         idx_s = fields.pop(0)
         result.append(NetworkctlListState(int(idx_s), *fields))
     return result
@@ -90,7 +90,7 @@ def get_networkctl_status(iface_name):
     data = collections.defaultdict(list)
     oldk = None
     for line in out.split(b'\n')[1:-1]:
-        line = line.decode('ascii')
+        line = line.decode('utf-8', errors='replace')
         k = line[:16].strip() or oldk
         oldk = k
         v = line[18:].strip()
@@ -114,7 +114,7 @@ def get_wlan_essid(iface_name):
 
 def iw_get_ssid(iface_name):
     out = subprocess.check_output([IW, iface_name, 'link'])
-    lines = out.decode('ascii').split('\n')
+    lines = out.decode('utf-8', errors='replace').split('\n')
     line = [s for s in lines if 'SSID' in s]
     if len(line) == 0:
         logger.warning('Unable to retrieve ESSID for wireless interface %s.'
@@ -126,7 +126,7 @@ def iw_get_ssid(iface_name):
 
 def iwconfig_get_ssid(iface_name):
     out = subprocess.check_output([IWCONFIG, '--', iface_name])
-    line = out.split(b'\n')[0].decode('ascii')
+    line = out.split(b'\n')[0].decode('utf-8', errors='replace')
     essid = line[line.find('ESSID:')+7:-3]
     return unquote(essid)
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6,11 +6,11 @@ function error() {
 }
 
 # Required binaries/apps
-reqs=('pytest' 'coverage')
+reqs=('pytest')
 for req in ${reqs[*]}; do
 	[[ -z "$(command -v $req)" ]] && error "$req not found"
 done
 # Check for pytest-cov module
-python -c "import pytest_cov" 2>/dev/null || error "pytest-cov module not found"
+python3 -c "import pytest_cov" 2>/dev/null || error "pytest-cov module not found"
 
-python -m pytest --cov=networkd_dispatcher -q tests
+python3 -m pytest --cov=networkd_dispatcher -q tests

--- a/tests/test_networkd-dispatcher.py
+++ b/tests/test_networkd-dispatcher.py
@@ -32,7 +32,7 @@ def test_get_networkctl_status(monkeypatch, get_input):
                 'Address': ['1.1.1.100'], 'Gateway': ['1.1.1.1'],
                 'DNS': ['10.10.10.1']}
     monkeypatch.setattr(subprocess, 'check_output',
-                        lambda cmd: get_input.encode())
+                        lambda cmd: get_input.encode('utf-8'))
     assert networkd_dispatcher.get_networkctl_status('wlan0') == expected
 
 
@@ -57,7 +57,7 @@ def test_get_networkctl_list(monkeypatch, get_input):
                                                 administrative='configured')
     ]
     monkeypatch.setattr(subprocess, 'check_output',
-                        lambda cmd: get_input.encode())
+                        lambda cmd: get_input.encode('utf-8'))
     assert networkd_dispatcher.get_networkctl_list() == expected
 
 
@@ -77,7 +77,7 @@ def test_get_wlan_ssid_iwconfig(monkeypatch, get_input):
     monkeypatch.setattr('networkd_dispatcher.IW', None)
     monkeypatch.setattr('networkd_dispatcher.IWCONFIG', '/usr/bin/iwconfig')
     monkeypatch.setattr(subprocess, 'check_output',
-                        lambda cmd: get_input.encode())
+                        lambda cmd: get_input.encode('utf-8'))
     assert networkd_dispatcher.get_wlan_essid('wlan0') == expected
 
 
@@ -86,5 +86,5 @@ def test_get_wlan_ssid_iw(monkeypatch, get_input):
     monkeypatch.setattr('networkd_dispatcher.IW', '/usr/bin/iw')
     monkeypatch.setattr('networkd_dispatcher.IWCONFIG', None)
     monkeypatch.setattr(subprocess, 'check_output',
-                        lambda cmd: get_input.encode())
+                        lambda cmd: get_input.encode('utf-8'))
     assert networkd_dispatcher.get_wlan_essid('wlan0') == expected


### PR DESCRIPTION
networkd-dispatcher uses python3 and should use utf-8 for
decode and encode.  Update tests to use utf-8 and python3.
Drop 'coverage' binary check, the python3 import is sufficient.